### PR TITLE
Fix repo name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to MCP Watch! This document provides
 1. **Fork the repository** on GitHub
 2. **Clone your fork** locally:
    ```bash
-   git clone https://github.com/yourusername/mcp-watch.git
+   git clone https://github.com/kapilduraphe/mcp-watch.git
    cd mcp-watch
    ```
 3. **Install dependencies**:
@@ -223,7 +223,7 @@ tests/fixtures/
 
 1. **Sync with upstream**:
    ```bash
-   git remote add upstream https://github.com/original/mcp-watch.git
+   git remote add upstream https://github.com/kapilduraphe/mcp-watch.git
    git fetch upstream
    git rebase upstream/main
    ```


### PR DESCRIPTION
This pull request updates the repository URLs in the `CONTRIBUTING.md` documentation to point to the correct GitHub user account. This ensures that contributors are directed to the right repository when cloning or syncing with upstream.

Documentation updates:

* Updated the `git clone` command to use `https://github.com/kapilduraphe/mcp-watch.git` instead of a placeholder username.
* Updated the `git remote add upstream` command to use `https://github.com/kapilduraphe/mcp-watch.git` instead of the original repository URL.