### PR TITLE
feat(local): add the mcp watch local support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,42 @@ A comprehensive security scanner for Model Context Protocol (MCP) servers that d
 - **🌊 Toxic Flows** - Identifies dangerous data flow patterns
 - **🔐 Permission Issues** - Finds excessive permissions and access control problems
 
+## Quick Start 🚀
+
+### Option 1: NPM Package (Recommended)
+```bash
+# Install globally
+npm install -g mcp-watch
+
+# Scan any GitHub MCP repository
+mcp-watch scan https://github.com/user/mcp-server
+
+# Scan your local MCP project
+mcp-watch scan-local /path/to/your/mcp-project
+```
+
+### Option 2: From GitHub Source
+```bash
+# Clone and use immediately
+git clone https://github.com/kapilduraphe/mcp-watch.git
+cd mcp-watch
+npm install
+npm run build
+
+# Scan GitHub repos
+npm run scan:github https://github.com/user/mcp-server
+
+# Scan local projects  
+npm run scan:local /path/to/your/mcp-project
+```
+
+### Option 3: Docker (No Installation)
+```bash
+# Scan without installing anything
+docker run --rm mcp-watch scan https://github.com/user/mcp-server
+docker run --rm -v $(pwd):/workspace mcp-watch scan-local /workspace
+```
+
 ## Installation
 
 ### Global Installation
@@ -77,6 +113,7 @@ docker compose run --rm mcp-watch scan https://github.com/user/repo
 
 ### Command Line
 
+#### Scan GitHub Repositories
 ```bash
 # Scan a GitHub repository
 mcp-watch scan https://github.com/user/mcp-server
@@ -91,9 +128,50 @@ mcp-watch scan https://github.com/user/mcp-server --severity high
 mcp-watch scan https://github.com/user/mcp-server --category credential-leak
 ```
 
-**Note:** If you don't want to download npm then just substitute `mcp-watch` with `node dist/main.js`.
+#### Scan Local Projects
+```bash
+# Scan current directory
+mcp-watch scan-local .
 
-**Example:** `node dist/main.js scan https://github.com/user/repo`
+# Scan specific directory (absolute path)
+mcp-watch scan-local /path/to/your/mcp-project
+
+# Scan specific directory (relative path)
+mcp-watch scan-local ../my-mcp-server
+
+# Local scan with JSON output
+mcp-watch scan-local . --format json
+
+# Local scan with severity filter
+mcp-watch scan-local . --severity high
+```
+
+### Installation Method Usage
+
+#### From NPM Package
+```bash
+# Global installation (recommended)
+npm install -g mcp-watch
+mcp-watch scan https://github.com/user/mcp-server
+mcp-watch scan-local /path/to/project
+```
+
+#### From GitHub Source
+```bash
+# Clone and build
+git clone https://github.com/kapilduraphe/mcp-watch.git
+cd mcp-watch
+npm install
+npm run build
+
+# Use built version
+node dist/main.js scan https://github.com/user/mcp-server
+node dist/main.js scan-local /path/to/project
+
+# Or use npm scripts
+npm run scan https://github.com/user/mcp-server
+npm run scan-local /path/to/project
+```
 
 ### Docker Usage 🐳
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "mcp-watch",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-watch",
-      "version": "0.1.0",
+      "version": "0.1.2",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/node": "^24.3.0",
+        "@types/node": "^24.3.1",
         "@types/tmp": "^0.2.4",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -451,9 +451,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -771,13 +771,16 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -864,22 +867,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ci-info": {
@@ -1022,13 +1009,17 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint": {
@@ -1130,34 +1121,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -1284,6 +1247,19 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1413,16 +1389,17 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
@@ -1721,19 +1698,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1859,6 +1823,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/minimatch": {
@@ -2020,13 +1997,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -2056,6 +2033,19 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -2220,6 +2210,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-watch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Security scanner for Model Context Protocol (MCP) servers - detect vulnerabilities and security issues",
   "main": "dist/main.js",
   "bin": {
@@ -11,10 +11,14 @@
     "dev": "ts-node src/main.ts",
     "start": "node dist/main.js",
     "scan": "ts-node src/main.ts scan",
+    "scan-local": "ts-node src/main.ts scan-local",
+    "scan:github": "node dist/main.js scan",
+    "scan:local": "node dist/main.js scan-local",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run clean && npm run build",
     "prepare": "npm run build",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "postinstall": "npm run build"
   },
   "author": "Kapil Duraphe",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0",
+    "@types/node": "^24.3.1",
     "@types/tmp": "^0.2.4",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,4 +114,104 @@ program
     }
   );
 
+program
+  .command("scan-local")
+  .description("Scan a local MCP server project directory for security vulnerabilities")
+  .argument("<project-path>", "Path to the local project directory")
+  .option("-f, --format <type>", "Output format (console|json)", "console")
+  .option(
+    "--severity <level>",
+    "Minimum severity level (low|medium|high|critical)",
+    "low"
+  )
+  .option("--category <cat>", "Filter by vulnerability category")
+  .action(
+    async (
+      projectPath: string,
+      options: {
+        format: string;
+        severity: string;
+        category?: string;
+      }
+    ) => {
+      try {
+        const scanner = new MCPScanner();
+        const allVulnerabilities = await scanner.scanLocalProject(projectPath);
+
+        // Apply filters
+        const severityOrder = { low: 0, medium: 1, high: 2, critical: 3 };
+        const minSeverity =
+          severityOrder[options.severity as keyof typeof severityOrder] || 0;
+
+        let vulnerabilities = allVulnerabilities.filter(
+          (v) => severityOrder[v.severity] >= minSeverity
+        );
+
+        if (options.category) {
+          vulnerabilities = vulnerabilities.filter(
+            (v) => v.category === options.category
+          );
+        }
+
+        if (options.format === "json") {
+          console.log(
+            JSON.stringify(
+              {
+                projectPath: projectPath,
+                scanDate: new Date().toISOString(),
+                scanner: "MCP Watch",
+                researchSources: [
+                  "VulnerableMCP Database",
+                  "HiddenLayer Research",
+                  "Invariant Labs Research",
+                  "Trail of Bits Research",
+                  "PromptHub Analysis",
+                ],
+                totalVulnerabilities: vulnerabilities.length,
+                severityCounts: vulnerabilities.reduce((acc, v) => {
+                  acc[v.severity] = (acc[v.severity] || 0) + 1;
+                  return acc;
+                }, {} as Record<string, number>),
+                categoryCounts: vulnerabilities.reduce((acc, v) => {
+                  acc[v.category] = (acc[v.category] || 0) + 1;
+                  return acc;
+                }, {} as Record<string, number>),
+                vulnerabilities,
+              },
+              null,
+              2
+            )
+          );
+        } else {
+          formatReport(vulnerabilities);
+        }
+
+        // Exit with error code if critical/high vulnerabilities found
+        const criticalOrHigh = vulnerabilities.filter(
+          (v) => v.severity === "critical" || v.severity === "high"
+        );
+        if (criticalOrHigh.length > 0) {
+          console.log(
+            `\n❌ Found ${criticalOrHigh.length} critical/high severity vulnerabilities`
+          );
+          console.log("🚨 Immediate action required!");
+          process.exit(1);
+        } else {
+          console.log(
+            "\n✅ No critical or high severity vulnerabilities found"
+          );
+          console.log(
+            "💚 MCP server appears secure based on current research!"
+          );
+        }
+      } catch (error) {
+        console.error(
+          "❌ Error:",
+          error instanceof Error ? error.message : error
+        );
+        process.exit(1);
+      }
+    }
+  );
+
 program.parse();

--- a/src/scanner/McpScanner.ts
+++ b/src/scanner/McpScanner.ts
@@ -102,6 +102,72 @@ export class MCPScanner {
   }
 
   /**
+   * Scans a local project directory for MCP security vulnerabilities
+   *
+   * @param projectPath - The local project directory path to scan
+   * @returns Promise resolving to array of discovered vulnerabilities
+   *
+   * @example
+   * ```typescript
+   * const scanner = new MCPScanner();
+   * const vulns = await scanner.scanLocalProject('./my-mcp-server');
+   * console.log(`Found ${vulns.length} vulnerabilities`);
+   * ```
+   */
+  async scanLocalProject(projectPath: string): Promise<Vulnerability[]> {
+    console.log(`🔍 Scanning local project: ${projectPath}`);
+    console.log(
+      "📊 Based on vulnerablemcp.info, HiddenLayer, Invariant Labs, and Trail of Bits research\n"
+    );
+
+    // Validate that the project path exists
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+
+    const stat = fs.statSync(projectPath);
+    if (!stat.isDirectory()) {
+      throw new Error(`Project path is not a directory: ${projectPath}`);
+    }
+
+    // Initialize all scanners
+    const credentialScanner = new CredentialScanner();
+    const toolPoisoningScanner = new ToolPoisoningScanner();
+    const parameterInjectionScanner = new ParameterInjectionScanner();
+    const promptInjectionScanner = new PromptInjectionScanner();
+    const toolMutationScanner = new ToolMutationScanner();
+    const conversationExfiltrationScanner =
+      new ConversationExfiltrationScanner();
+    const ansiInjectionScanner = new AnsiInjectionScanner();
+    const protocolViolationScanner = new ProtocolViolationScanner();
+    const inputValidationScanner = new InputValidationScanner();
+    const serverSpoofingScanner = new ServerSpoofingScanner();
+    const toxicFlowScanner = new ToxicFlowScanner();
+    const permissionScanner = new PermissionScanner();
+
+    // Core vulnerability scans based on documented research
+    const scanResults = await Promise.all([
+      credentialScanner.scan(projectPath),
+      toolPoisoningScanner.scan(projectPath),
+      parameterInjectionScanner.scan(projectPath),
+      promptInjectionScanner.scan(projectPath),
+      toolMutationScanner.scan(projectPath),
+      conversationExfiltrationScanner.scan(projectPath),
+      ansiInjectionScanner.scan(projectPath),
+      protocolViolationScanner.scan(projectPath),
+      inputValidationScanner.scan(projectPath),
+      serverSpoofingScanner.scan(projectPath),
+      toxicFlowScanner.scan(projectPath),
+      permissionScanner.scan(projectPath),
+    ]);
+
+    // Flatten all vulnerabilities from all scanners
+    this.vulnerabilities = scanResults.flat();
+
+    return this.vulnerabilities;
+  }
+
+  /**
    * Clones a Git repository to a temporary directory
    *
    * @param url - The repository URL to clone


### PR DESCRIPTION
This pull request introduces a major new feature: support for scanning local Model Context Protocol (MCP) projects for security vulnerabilities, in addition to existing GitHub repository scanning. The update adds a new CLI command, updates documentation to reflect usage options, and enhances the package's usability for both local and remote scanning scenarios. Other improvements include new npm scripts, a version bump, and better documentation for installation and usage.

**New Local Project Scanning Feature:**

* Added a `scan-local` CLI command to `src/main.ts` that scans a specified local directory for MCP vulnerabilities, supports filtering by severity and category, and outputs results in either console or JSON format. The command exits with an error code if critical or high severity vulnerabilities are found.
* Implemented the `scanLocalProject` method in `MCPScanner` (`src/scanner/McpScanner.ts`) to orchestrate scanning a local directory using all vulnerability scanners, with input validation and research source attribution.

**Documentation & Usability Improvements:**

* Updated `README.md` to include a "Quick Start" section, detailed instructions for scanning local projects, and clarified installation and usage for npm, GitHub source, and Docker. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R174)

**Build & Packaging Enhancements:**

* Added new npm scripts (`scan-local`, `scan:github`, `scan:local`) and a `postinstall` build step in `package.json` for improved developer and user experience.
* Bumped the package version from `0.1.1` to `0.1.2` to reflect the new functionality.