### PR TITLE
Hardened Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ ehthumbs.db
 Thumbs.db
 
 # IDE files
+.devcontainer/
 .vscode/
 .idea/
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,12 +47,9 @@ RUN rm -rf /usr/local/bin/docker-entrypoint.sh \
     /usr/local/bin/npx \
     /usr/local/lib/node_modules/npm \
     /usr/local/lib/node_modules/corepack && \
-    find /usr -type f \( -name "curl" -o \) -delete && \
     find /bin /sbin /usr/bin /usr/sbin -type f \( \
-        -name "apk" -o -name "apk-tools" -o \
-        -name "curl" -o -name "openssh*" \
+        -name "apk" -o -name "apk-tools" -o -name "openssh*" \
     \) -delete 2>/dev/null || true
-
 
 # Switch to nodejs user
 USER nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY package*.json ./
 COPY tsconfig.json ./
 COPY src/ ./src/
 
+# Ensure latest NPM
+RUN npm i -g npm@latest
+
 # Install ALL dependencies (including dev dependencies for building)
 RUN npm ci
 
@@ -37,6 +40,19 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 # Change ownership to nodejs user
 RUN chown -R nodejs:nodejs /app
+
+# Remove unnecessary binaries and tools to harden the image
+RUN rm -rf /usr/local/bin/docker-entrypoint.sh \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack && \
+    find /usr -type f \( -name "curl" -o \) -delete && \
+    find /bin /sbin /usr/bin /usr/sbin -type f \( \
+        -name "apk" -o -name "apk-tools" -o \
+        -name "curl" -o -name "openssh*" \
+    \) -delete 2>/dev/null || true
+
 
 # Switch to nodejs user
 USER nodejs


### PR DESCRIPTION
# PR changes
This PR introduces a couple lines to the Dockerfile for the purpose of improving security:

- added script to keep NPM updated
- removed system package manager `apk`, and `openssh`

## Motivation
This further supports the claim in the README regarding the Dockerfile:
 
"- 🔒 Security: Non-root user, minimal attack surface"

## .gitignore
In addition, added `.devcontainer/` directory to .gitignore. If the devcontainer functionality is useful for others, I can introduce the directories, files, and update contributing documentation in another update.

# Next Steps
- Migrate eslint to v9
- eliminate `deprecated` warnings in `npm install`
- discuss the addition of a workflow to automate building and pushing the docker image to a container registry (Docker Hub and/or GitHub)